### PR TITLE
Fix for automatic pin placement for ALL USERS using 1,2 keys.

### DIFF
--- a/Release.js
+++ b/Release.js
@@ -69,7 +69,8 @@ function placeMarker(safeMode){
 
     // Okay well played Geoguessr u got me there for a minute, but below should work.
     // Below is the only intentionally complicated part of the code - it won't be simplified or explained for good reason.
-    let element = document.getElementsByClassName("guess-map_canvas__JAHHT")[0]
+    // let element = document.getElementsByClassName("guess-map_canvas__JAHHT")[0]
+    let element = document.querySelectorAll('[class^="guess-map_canvas__"]')[0]
     if(!element){
         placeMarkerStreaks()
         return


### PR DESCRIPTION
It appears that class="guess-map_canvasXXXXX" (where XXXXX are 5 random letters) is different for each person or is often updated by developers. With the current `document.getElementsByClassName("guess-map_canvasJAHHT")[0]` setting pins on the map would only work for the creator @0x978 .

By changing line 75 in Release.js to
`let element = document.querySelectorAll('[class^="guess-map_canvas__"]')[0]`
we can successfully pattern match the map canvas and pins will start working for any user and will work with future updates of Geoguessr.
