### PR TITLE
Fix for no coordinates from Google API in some gamemodes or locations

### DIFF
--- a/Release.js
+++ b/Release.js
@@ -32,7 +32,9 @@ XMLHttpRequest.prototype.open = function(method, url) {
     // Geoguessr now calls the Google Maps API multiple times each round, with subsequent requests overwriting
     // the saved coordinates. Calls to this exact API path seems to be legitimate for now. A better solution than panoID currently?
     // Needs testing.
-    if (url.startsWith('https://maps.googleapis.com/$rpc/google.internal.maps.mapsjs.v1.MapsJsInternalService/GetMetadata')) {
+    if (method.toUpperCase() === 'POST' &&
+        (url.startsWith('https://maps.googleapis.com/$rpc/google.internal.maps.mapsjs.v1.MapsJsInternalService/GetMetadata') ||
+         url.startsWith('https://maps.googleapis.com/$rpc/google.internal.maps.mapsjs.v1.MapsJsInternalService/SingleImageSearch'))) {
 
         this.addEventListener('load', function () {
             let interceptedResult = this.responseText


### PR DESCRIPTION
- Fixes #18 and probably other related issues.

I've also faced that issue, but only when I was playing no move in some locations. I figured out that the problem was about the `XMLHttpRequest.prototype.open` function, because for some locations it worked properly, and for some locations it wasn't called at all. I went through some problematic locations again but with DevTools Network tab opened, and found that not only `GetMetadata` Google API's endpoint is used, but sometimes also `SingleImageSearch`, that provides exact or similar information to `GetMetadata`. So I added `SingleImageSearch` endpoint as well, and tested it for a while, and it seems like adding it fixes the issue.

I've also added a check for the method to be a `POST`, because requests to these endpoints are preceded by `OPTIONS` requests, that don't contain any useful information for parsing coordinates.