### PR TITLE
Fix for mapsFromCoords function doesn't work in Firefox

### DIFF
--- a/Release.js
+++ b/Release.js
@@ -138,9 +138,14 @@ function mapsFromCoords() { // opens new Google Maps location using coords.
         return;
     }
 
-    // Reject any attempt to call an overridden window.open, or fail .
-    if(nativeOpen && nativeOpen.toString().indexOf('native code') === 19){
-        nativeOpen(`https://maps.google.com/?output=embed&q=${lat},${lng}&ll=${lat},${lng}&z=5`);
+    if (nativeOpen) {
+        const nativeOpenCodeIndex = nativeOpen.toString().indexOf('native code')
+
+        // Reject any attempt to call an overridden window.open, or fail.
+        // 19 is for chromium-based browsers; 23 is for firefox-based browsers.
+        if (nativeOpenCodeIndex === 19 || nativeOpenCodeIndex === 23) {
+            nativeOpen(`https://maps.google.com/?output=embed&q=${lat},${lng}&ll=${lat},${lng}&z=5`);
+        }
     }
 }
 


### PR DESCRIPTION
For some reason, in Chromium-based and Firefox-based browsers, the conversion of a function into a string works differently, so when we try to get the index of `'native code'` we get different results. The best approach would be, of course, to use regex or to somehow parse it other way, but it feels like that is unnecessary, because the result of `nativeOpen.toString().indexOf('native code')` is always either 19 for Chrome or 23 for Firefox:

```js
// nativeOpen.toString() in Chromium-based browsers
function open() { [native code] }
```

```js
// nativeOpen.toString() in Firefox-based browsers
function open() {
    [native code]
}
```